### PR TITLE
Authentication fix

### DIFF
--- a/src/XboxCsMgr.Client/Bootstrapper.cs
+++ b/src/XboxCsMgr.Client/Bootstrapper.cs
@@ -68,7 +68,7 @@ namespace XboxCsMgr.Client
                     }
                     else if (credential.Key.Contains("Utoken"))
                     {
-                        UserToken = token.TokenData.Token;
+                        if (token.TokenData.Token != "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") UserToken = token.TokenData.Token;
                     }
                 }
             }


### PR DESCRIPTION
I added a check to stop an invalid token (`"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"`) from being written to `UserToken` in `Bootstrap.cs`. It's somewhat of a slap-on fix, a better one would be to see if any bad values were being sent in Xbox Live requests and stop them from being made, but this seems to do the job just fine.